### PR TITLE
Fix Gender Filter Issue in Opening and Closing Ranks Tab

### DIFF
--- a/error.md
+++ b/error.md
@@ -1,0 +1,13 @@
+Hey @nikkuAg,
+
+I encountered an issue with the gender filter option on the "Opening and Closing Ranks" tab of your Rank Matrix website. When I apply the gender filter, the page returns empty results. This seems to be a problem with the `/rank` API endpoint.
+
+Could you please investigate and resolve this as soon as possible?
+
+I've attached screenshots for reference:
+
+![Filter Issue Screenshot 1](https://github.com/charann29/rank-matrix-ngnix/assets/91114649/de0fe0a7-42ef-490c-8e3a-0108234d386e)
+
+![Filter Issue Screenshot 2](https://github.com/charann29/rank-matrix-ngnix/assets/91114649/a6b63dd6-e069-4517-90dc-c64616681099)
+
+Thank you!


### PR DESCRIPTION
## Summary
This PR addresses an issue with the gender filter option on the "Opening and Closing Ranks" tab of the Rank Matrix website. When the gender filter is applied, the page returns empty results, indicating a potential problem with the `/rank` API endpoint.

## Details
- **Issue**: Gender filter returns empty results.
- **Cause**: Suspected problem with the `/rank` API endpoint.

## Steps to Reproduce
1. Navigate to the "Opening and Closing Ranks" tab.
2. Apply the gender filter.
3. Observe that the page returns empty results.

## Screenshots
![Filter Issue Screenshot 1](https://github.com/charann29/rank-matrix-ngnix/assets/91114649/de0fe0a7-42ef-490c-8e3a-0108234d386e)
![Filter Issue Screenshot 2](https://github.com/charann29/rank-matrix-ngnix/assets/91114649/a6b63dd6-e069-4517-90dc-c64616681099)

## Request
Please investigate and resolve this issue as soon as possible.

Thank you!
